### PR TITLE
Fix: Mockserver (module is not defined)

### DIFF
--- a/src/mockserver.js
+++ b/src/mockserver.js
@@ -4,10 +4,16 @@ var config = window.__karma__.config,
 
 //workaround for crossroads/mockserver issue
 (function() {
-	var original = module;
-	module = undefined;
+	var original;
+	if (typeof module !== "undefined") {
+	    original = module;
+	    module = undefined;
+	}
 	jQuery.sap.require("sap.ui.core.util.MockServer");
-	module = original;
+	if (typeof original !== "undefined") {
+	    module = original;
+	    original = undefined;
+	}
 })();
 
 mockserverConfig.config = mockserverConfig.config ||{};


### PR DESCRIPTION
Fixes #1:
Uncaught ReferenceError: module is not defined
at /node_modules/karma-openui5/lib/mockserver.js:7

I hereby declare to agree to the OpenUI5 Individual Contributor License
Agreement.