### PR TITLE
Add autorun feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 lib/adapter.js
+lib/autorun.js
 lib/mockserver.js
 node_modules
 npm-debug.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,10 +3,12 @@ module.exports = function (grunt) {
 		pkgFile: 'package.json',
 		files: {
 			adapter: ['src/adapter.js'],
+			autorun: ['src/autorun.js'],
 			mockserver: ['src/mockserver.js']
 		},
 		build: {
 			adapter: '<%= files.adapter %>',
+			autorun: '<%= files.autorun %>',
 			mockserver: '<%= files.mockserver %>'
 		},
 		'npm-publish': {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The following code shows the available configuration options.
 For the client OpenUI5 configuration you can create an object using any of the options described in the
 [documentation](https://openui5.hana.ondemand.com/docs/guide/91f2d03b6f4d1014b6dd926db0e91070.html).
 
+To automatically load test modules (via `sap.ui.require`), the `tests` config can be set to an array of module names. When using this config, the relevant files must not be included via the `files` config of Karma.<br>
+This is very similar to [how RequireJS works with Karma](https://karma-runner.github.io/2.0/plus/requirejs.html), but without the need for a custom `test-main.js` file.
+
 For the mockserver config you can pass an object like you would do it for the ``sap.ui.core.util.MockServer.config``
 function. The rootUri and the metadataURL are required properties if you use the mock server. You can also pass
 mockdata settings like you would do it for the ``simulate`` function of the MockServer. The MockServer needs to be
@@ -44,6 +47,10 @@ module.exports = function(config) {
         config: {
           theme: 'sap_belize'
         },
+        tests: [
+          'name/of/test/module/to/be/loaded',
+          'other/name/of/test/module/to/be/loaded'
+        ],
         mockserver: {
           config: {
             autoRespond: true
@@ -68,31 +75,6 @@ Therefore rather load those resources in the non-karma specific test runner HTML
 ````html
     <script src="../../resources/sap/ui/thirdparty/qunit.js"></script>
     <script src="../../resources/sap/ui/qunit/qunit-css.js"></script>
-````
-
-### Delaying Karma start
-Karma loads all given files via script tags. It expects them to register all tests synchronously so that it can start the execution right away.
-
-When using asynchronous preloads or the AMD syntax `sap.ui.define` or `sap.ui.require`, the Karma test execution needs to be delayed.
-
-We therefore have an additional file exclusively for Karma, loading all our tests and postponing the execution until everything is ready:
-````javascript
-(function (karma) {
-    "use strict";
-
-    // Prevent Karma from running prematurely.
-    karma.loaded = function () {};
-
-    sap.ui.getCore().attachInit(function() {
-        sap.ui.require([
-            "sap/ui/demo/todo/test/unit/allTests",
-            "sap/ui/demo/todo/test/integration/AllJourneys"
-        ], function() {
-            // Finally, start Karma to run the tests.
-            karma.start();
-        });
-    });
-})(window.__karma__)
 ````
 
 ### OPA5: Component containers instead of iFrames

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,9 @@ var isUrlAbsolute = function(url) {
 };
 
 var initOpenUI5 = function (files, ui5Config, basePath) {
+
+	files.unshift({pattern: __dirname + '/autorun.js', included: true, served: true, watched: false});
+
 	if (ui5Config.useMockServer) {
 		files.unshift({pattern: __dirname + '/mockserver.js', included: true, served: true, watched: false});
 	}

--- a/src/autorun.js
+++ b/src/autorun.js
@@ -1,0 +1,20 @@
+var karma = window.__karma__;
+var config = karma.config;
+var ui5config = (config && config.openui5) || {};
+var ui5configTests = ui5config.tests;
+
+if (!ui5configTests) {
+	// No tests defined - skipping autorun...
+	// Tests must be loaded manually
+	return;
+}
+
+// Prevent Karma from running prematurely.
+karma.loaded = function () {};
+
+sap.ui.getCore().attachInit(function() {
+	sap.ui.require(ui5configTests, function() {
+		// Finally, start Karma to run the tests.
+		karma.start();
+	});
+});

--- a/src/autorun.wrapper
+++ b/src/autorun.wrapper
@@ -1,0 +1,5 @@
+(function(window) {
+
+%CONTENT%
+
+})(window);


### PR DESCRIPTION
Test modules can be defined in the openui5 config and will be loaded
automatically via sap.ui.require.
So a custom "karma-main.js" is not require anymore, but can still be
used to manually load and run tests.